### PR TITLE
Confidant communications patch 1

### DIFF
--- a/_docs/project-files/xml-format.md
+++ b/_docs/project-files/xml-format.md
@@ -253,7 +253,12 @@ Use `<dependency />` tags to specify native frameworks or references that are re
 
 <details>
 <summary>&lt;echo /&gt;</summary>
-More to come.
+Prints specified message to the console:
+
+```
+<echo value="Some output message" />
+```
+
 </details>
 
 <details>

--- a/_docs/project-files/xml-format.md
+++ b/_docs/project-files/xml-format.md
@@ -68,17 +68,7 @@ You can include more than one copy of each tag, so do not worry about putting it
 
 If you create a haxelib, you can add "include.xml" to the top-level directory. The build tools will automatically add the contents of the file to the user's project. You can use this to add binary dependencies, additional classpaths, etc.
 
-## Common Tags (click to expand)
-<details>
-<summary>&lt;meta /&gt;</summary>
-
-Use `<meta />` tags to add information about your application, which usually will not affect how the application runs, but how it is identified to the target operating system or on an application store:
-
-```xml
-<meta title="My Application" package="com.example.myapplication" version="1.0.0" company="My Company" />
-```
-</details>
-
+## XML Tag Glossary (click to expand)
 <details>
 <summary>&lt;app /&gt;</summary>
 
@@ -91,97 +81,16 @@ The `<app />` tag sets values important to building your project, including the 
 </details>
 
 <details>
-<summary>&lt;window /&gt;</summary>
+<summary>&lt;architecture /&gt;</summary>
 
-You can use `<window />` tags to control how an application will be initialized. This includes the screen resolution and background color, as well as other options, such as whether hardware should be allowed or display mode flags.
+Use `<architecture />` tags to set or exclude Android-specific architectures. These can be `ARMv7`, `ARMv6`, `ARMv5` and `X86`.
 
-By default, mobile platforms use a window width and height of 0, which is a special value that uses the resolution of the current display. This is available on desktop platforms, but usually it is recommended to enable the `fullscreen` flag instead, and to set the `width` and `height` values to a good windowed resolution. There is a special `fps="0"` value for HTML5, which is default, which uses "requestAnimationFrame" instead of forcing a frame rate.
+By default the only architecture built will be `ARMv7`.
 
-```xml
-<window width="640" height="480" background="#FFFFFF" fps="30" />
-<window hardware="true" allow-shaders="true" require-shaders="true" depth-buffer="false" stencil-buffer="false" />
-<window fullscreen="false" resizable="true" borderless="false" vsync="false" />
-<window orientation="portrait" />
-```
-
-The `orientation` value expects either "portrait" or "landscape" ... the default is "auto" which allows the operating system to decide which orientation to use.
-
-</details>
-
-<details>
-<summary>&lt;source /&gt;</summary>
-
-Use `<source />` tags to add Haxe class paths:
+For example, if you want to enable `ARMv6` and disable `ARMv7` you would set the `<architecture />` tag to:
 
 ```xml
-<source path="Source" />
-```
-
-If you are using `@:file`, `@:bitmap`, `@:sound` or `@:file` tags in your project, be sure that the asset files are available within your Haxe source paths.
-
-</details>
-
-<details>
-<summary>&lt;haxelib /&gt;</summary>
-
-Use `<haxelib />` tags to include Haxe libraries:
-
-```xml
-<haxelib name="actuate" />
-```
-
-You can also specify a version, if you prefer:
-
-```xml
-<haxelib name="actuate" version="1.0.0" />
-```
-
-</details>
-
-<details>
-<summary>&lt;section /&gt;</summary>
-
-The `<section />` tag is used to group other tags together. This is usually most valuable when combined with "if" and/or "unless" logic:
-
-```xml
-<section if="html5">
-	<source path="extra/src/html5" />
-</section>
-```
-</details>
-
-<details>
-<summary>&lt;ndll /&gt;</summary>
-
-You can use `<ndll />` tags to include native libraries. These are usually located under an "ndll" directory, with additional directories based upon the target platform. Usually an `<ndll />` tag will be included as a part of an extension, and is rare to be used directly:
-
-```xml
-<ndll name="std" haxelib="hxcpp" />
-```
-
-</details>
-
-<details>
-<summary>&lt;include /&gt;</summary>
-
-Use `<include />` tags to add the tags found in another project file, or to find an "include.xml" file in the target directory:
-
-```xml
-<include path="to/another/project.xml" />
-<include path="to/shared/library" />
-```
-
-</details>
-
-<details>
-<summary>&lt;icon /&gt;</summary>
-
-Use `<icon />` nodes to add icon files to your project. When the command-line tools request icons for a target platform, it will either use an exact size match you have provided, or it will attempt to find the closest match possible and resize. If you include an SVG vector icon, it should prefer this file over resizing bitmap files.
-
-```xml
-<icon path="icon.png" size="64" />
-<icon path="icon.png" width="96" height="96" />
-<icon path="icon.svg" />
+<architecture name="armv6" exclude="armv7" if="android" />
 ```
 
 </details>
@@ -245,68 +154,6 @@ If an asset is specified as "template", it will not be copied/embedded as an ord
 </details>
 
 <details>
-<summary>&lt;template /&gt;</summary>
-
-Use `<template />` tags to add paths which can override the templates used by the command-line tools.
-
-You can add a full template path like this:
-
-```xml
-<template path="templates" />
-```
-
-Otherwise, you can override a single file like this:
-
-```xml
-<template path="Assets/index.html" rename="index.html" />
-```
-</details>
-
-<details>
-<summary>&lt;haxeflag /&gt;</summary>
-
-Use `<haxeflag />` tags to add additional arguments in the Haxe compile process:
-
-```xml
-<haxeflag name="-dce" value="std" />
-```
-
-</details>
-
-<details>
-<summary>&lt;haxedef /&gt;</summary>
-
-Use `<haxedef />` tags to add Haxe defines (similar to using a `<haxeflag />` with "-D"):
-
-```xml
-<haxedef name="define" />
-```
-
-</details>
-
-<details>
-<summary>&lt;setenv /&gt;</summary>
-
-Use `<setenv />` tags to set environment variables:
-
-```xml
-<setenv name="GLOBAL_DEFINE" />
-```
-
-</details>
-
-<details>
-<summary>&lt;java /&gt;</summary>
-
-Use `<java />` tags to add Java classes to the project when targeting Android:
-
-```xml
-<java path="to/classes" />
-```
-
-</details>
-
-<details>
 <summary>&lt;certificate /&gt;</summary>
 
 Use `<certificate />` tags to add a keystore for release signing on certain platforms.
@@ -330,20 +177,6 @@ iOS does not use a certificate `path` and `password`, but instead uses a `team-i
 </details>
 
 <details>
-<summary>&lt;config:ios /&gt;</summary>
-
-Control iOS-specific values when compiling.
-
-The `deployment` attribute can set the minimum iOS version you wish to target. The `prerendered-icon` attribute can help control the style of your icon.
-
-```xml
-<config:ios deployment="5.1" />
-<config:ios prerendered-icon="false" />
-```
-
-</details>
-
-<details>
 <summary>&lt;config:android /&gt;</summary>
 
 Use `<config:android />` tags to set Android-specific values:
@@ -357,16 +190,15 @@ Use `<config:android />` tags to set Android-specific values:
 </details>
 
 <details>
-<summary>&lt;architecture /&gt;</summary>
+<summary>&lt;config:ios /&gt;</summary>
 
-Use `<architecture />` tags to set or exclude Android-specific architectures. These can be `ARMv7`, `ARMv6`, `ARMv5` and `X86`.
+Control iOS-specific values when compiling.
 
-By default the only architecture built will be `ARMv7`.
-
-For example, if you want to enable `ARMv6` and disable `ARMv7` you would set the `<architecture />` tag to:
+The `deployment` attribute can set the minimum iOS version you wish to target. The `prerendered-icon` attribute can help control the style of your icon.
 
 ```xml
-<architecture name="armv6" exclude="armv7" if="android" />
+<config:ios deployment="5.1" />
+<config:ios prerendered-icon="false" />
 ```
 
 </details>
@@ -383,12 +215,76 @@ Use `<dependency />` tags to specify native frameworks or references that are re
 </details>
 
 <details>
-<summary>&lt;path /&gt;</summary>
+<summary>&lt;haxedef /&gt;</summary>
 
-Use `<path />` tags to add directories to your system's PATH environment variable.
+Use `<haxedef />` tags to add Haxe defines (similar to using a `<haxeflag />` with "-D"):
 
 ```xml
-<path value="path/to/add/to/system/PATH" />
+<haxedef name="define" />
+```
+
+</details>
+
+<details>
+<summary>&lt;haxeflag /&gt;</summary>
+
+Use `<haxeflag />` tags to add additional arguments in the Haxe compile process:
+
+```xml
+<haxeflag name="-dce" value="std" />
+```
+
+</details>
+
+<details>
+<summary>&lt;haxelib /&gt;</summary>
+
+Use `<haxelib />` tags to include Haxe libraries:
+
+```xml
+<haxelib name="actuate" />
+```
+
+You can also specify a version, if you prefer:
+
+```xml
+<haxelib name="actuate" version="1.0.0" />
+```
+
+</details>
+
+<details>
+<summary>&lt;icon /&gt;</summary>
+
+Use `<icon />` nodes to add icon files to your project. When the command-line tools request icons for a target platform, it will either use an exact size match you have provided, or it will attempt to find the closest match possible and resize. If you include an SVG vector icon, it should prefer this file over resizing bitmap files.
+
+```xml
+<icon path="icon.png" size="64" />
+<icon path="icon.png" width="96" height="96" />
+<icon path="icon.svg" />
+```
+
+</details>
+
+<details>
+<summary>&lt;include /&gt;</summary>
+
+Use `<include />` tags to add the tags found in another project file, or to find an "include.xml" file in the target directory:
+
+```xml
+<include path="to/another/project.xml" />
+<include path="to/shared/library" />
+```
+
+</details>
+
+<details>
+<summary>&lt;java /&gt;</summary>
+
+Use `<java />` tags to add Java classes to the project when targeting Android:
+
+```xml
+<java path="to/classes" />
 ```
 
 </details>
@@ -426,3 +322,108 @@ Be sure to specify the correct library when retrieving the assets in your code. 
 You can also use `Assets.unloadLibrary` when you are doing using those resources.
 
 </details>
+
+<details>
+<summary>&lt;meta /&gt;</summary>
+
+Use `<meta />` tags to add information about your application, which usually will not affect how the application runs, but how it is identified to the target operating system or on an application store:
+
+```xml
+<meta title="My Application" package="com.example.myapplication" version="1.0.0" company="My Company" />
+```
+</details>
+
+<details>
+<summary>&lt;ndll /&gt;</summary>
+
+You can use `<ndll />` tags to include native libraries. These are usually located under an "ndll" directory, with additional directories based upon the target platform. Usually an `<ndll />` tag will be included as a part of an extension, and is rare to be used directly:
+
+```xml
+<ndll name="std" haxelib="hxcpp" />
+```
+
+</details>
+
+<details>
+<summary>&lt;path /&gt;</summary>
+
+Use `<path />` tags to add directories to your system's PATH environment variable.
+
+```xml
+<path value="path/to/add/to/system/PATH" />
+```
+
+</details>
+
+<details>
+<summary>&lt;section /&gt;</summary>
+
+The `<section />` tag is used to group other tags together. This is usually most valuable when combined with "if" and/or "unless" logic:
+
+```xml
+<section if="html5">
+	<source path="extra/src/html5" />
+</section>
+```
+</details>
+
+<details>
+<summary>&lt;setenv /&gt;</summary>
+
+Use `<setenv />` tags to set environment variables:
+
+```xml
+<setenv name="GLOBAL_DEFINE" />
+```
+
+</details>
+
+<details>
+<summary>&lt;source /&gt;</summary>
+
+Use `<source />` tags to add Haxe class paths:
+
+```xml
+<source path="Source" />
+```
+
+If you are using `@:file`, `@:bitmap`, `@:sound` or `@:file` tags in your project, be sure that the asset files are available within your Haxe source paths.
+
+</details>
+
+<details>
+<summary>&lt;template /&gt;</summary>
+
+Use `<template />` tags to add paths which can override the templates used by the command-line tools.
+
+You can add a full template path like this:
+
+```xml
+<template path="templates" />
+```
+
+Otherwise, you can override a single file like this:
+
+```xml
+<template path="Assets/index.html" rename="index.html" />
+```
+</details>
+
+<details>
+<summary>&lt;window /&gt;</summary>
+
+You can use `<window />` tags to control how an application will be initialized. This includes the screen resolution and background color, as well as other options, such as whether hardware should be allowed or display mode flags.
+
+By default, mobile platforms use a window width and height of 0, which is a special value that uses the resolution of the current display. This is available on desktop platforms, but usually it is recommended to enable the `fullscreen` flag instead, and to set the `width` and `height` values to a good windowed resolution. There is a special `fps="0"` value for HTML5, which is default, which uses "requestAnimationFrame" instead of forcing a frame rate.
+
+```xml
+<window width="640" height="480" background="#FFFFFF" fps="30" />
+<window hardware="true" allow-shaders="true" require-shaders="true" depth-buffer="false" stencil-buffer="false" />
+<window fullscreen="false" resizable="true" borderless="false" vsync="false" />
+<window orientation="portrait" />
+```
+
+The `orientation` value expects either "portrait" or "landscape" ... the default is "auto" which allows the operating system to decide which orientation to use.
+
+</details>
+

--- a/_docs/project-files/xml-format.md
+++ b/_docs/project-files/xml-format.md
@@ -621,7 +621,7 @@ See "template"
 
 <details>
 <summary>&lt;undefine /&gt;</summary>
-Resets previously defined flag. See entry for `&lt;define /&gt;`.
+Resets previously defined flag. See entry for `<define />`.
 
 ```
 <undefine name="red" />
@@ -632,7 +632,7 @@ Resets previously defined flag. See entry for `&lt;define /&gt;`.
 <details>
 <summary>&lt;unset /&gt;</summary>
 
-Unsets previously defined value. See entry for `&lt;set /&gt;`.
+Unsets previously defined value. See entry for `<set />`.
 	
 ```
 <set name="red" value="0xff0000" />

--- a/_docs/project-files/xml-format.md
+++ b/_docs/project-files/xml-format.md
@@ -204,6 +204,17 @@ The `deployment` attribute can set the minimum iOS version you wish to target. T
 </details>
 
 <details>
+<summary>&lt;define /&gt;</summary>
+
+Similar to `<set />` tag, use `<define />` to also pass values to Haxe. See the “Conditionals” section above.
+
+```xml
+<dependency name="GameKit.framework" if="ios" />
+```
+
+</details>
+
+<details>
 <summary>&lt;dependency /&gt;</summary>
 
 Use `<dependency />` tags to specify native frameworks or references that are required to compile your project, as well as additional libraries you need copied.
@@ -368,6 +379,17 @@ The `<section />` tag is used to group other tags together. This is usually most
 </details>
 
 <details>
+<summary>&lt;set /&gt;</summary>
+
+Use `<set />` tags to set variables for conditional logic. See the “Conditionals” section above.
+
+```xml
+<set name="red" />
+```
+
+</details>
+
+<details>
 <summary>&lt;setenv /&gt;</summary>
 
 Use `<setenv />` tags to set environment variables:
@@ -405,7 +427,7 @@ You can add a full template path like this:
 Otherwise, you can override a single file like this:
 
 ```xml
-<template path="Assets/index.html" rename="index.html" />
+<template path="Assets/index.html" rename="index.php" />
 ```
 </details>
 

--- a/_docs/project-files/xml-format.md
+++ b/_docs/project-files/xml-format.md
@@ -30,7 +30,7 @@ This can also be used to pass special values:
 <window background="${color}" if="color" />
 ```
 
-Similarly, you can `<define />` which also passes values to Haxe
+Similarly, you can `<define />` or `<undefine />` values which are also passed to Haxe.
 
 ```xml
 <define name="red" />
@@ -544,12 +544,12 @@ More to come.
 
 <details>
 <summary>&lt;undefine /&gt;</summary>
-More to come.
+See entry for `<define />`.
 </details>
 
 <details>
 <summary>&lt;unset /&gt;</summary>
-More to come.
+See entry for `<set />`.
 </details>
 
 <details>

--- a/_docs/project-files/xml-format.md
+++ b/_docs/project-files/xml-format.md
@@ -621,7 +621,7 @@ See "template"
 
 <details>
 <summary>&lt;undefine /&gt;</summary>
-Resets previously defined flag. See entry for `<define />`.
+Resets previously defined flag. See entry for `&lt;define /&gt;`.
 
 ```
 <undefine name="red" />

--- a/_docs/project-files/xml-format.md
+++ b/_docs/project-files/xml-format.md
@@ -418,7 +418,18 @@ You can also use `Assets.unloadLibrary` when you are doing using those resources
 
 <details>
 <summary>&lt;log /&gt;</summary>
-More to come.
+Logs error (see "error"), warning or info message.
+
+Examples:
+
+```
+<log error="error message" />
+<log warn="warn message" />
+<log info="info message" />
+<log value="your message" />
+<log verbose="verbose message" />
+```
+	
 </details>
 
 <details>

--- a/_docs/project-files/xml-format.md
+++ b/_docs/project-files/xml-format.md
@@ -70,8 +70,7 @@ If you create a haxelib, you can add "include.xml" to the top-level directory. T
 
 ## Common Tags (click to expand)
 <details>
-<summary>
-### `<meta />`</summary>
+<summary>`<meta />`</summary>
 
 Use `<meta />` tags to add information about your application, which usually will not affect how the application runs, but how it is identified to the target operating system or on an application store:
 
@@ -81,8 +80,7 @@ Use `<meta />` tags to add information about your application, which usually wil
 </details>
 
 <details>
-<summary>
-### `<app />`</summary>
+<summary>`<app />`</summary>
 
 The `<app />` tag sets values important to building your project, including the entry point (main class), the output file directory, or if you want to customize the executable filename or define a custom preloader for a web platform:
 
@@ -93,8 +91,7 @@ The `<app />` tag sets values important to building your project, including the 
 </details>
 
 <details>
-<summary>
-### `<window />`</summary>
+<summary>`<window />`</summary>
 
 You can use `<window />` tags to control how an application will be initialized. This includes the screen resolution and background color, as well as other options, such as whether hardware should be allowed or display mode flags.
 
@@ -112,8 +109,7 @@ The `orientation` value expects either "portrait" or "landscape" ... the default
 </details>
 
 <details>
-<summary>
-### `<source />`</summary>
+<summary>`<source />`</summary>
 
 Use `<source />` tags to add Haxe class paths:
 
@@ -126,8 +122,7 @@ If you are using `@:file`, `@:bitmap`, `@:sound` or `@:file` tags in your projec
 </details>
 
 <details>
-<summary>
-### `<haxelib />`</summary>
+<summary>`<haxelib />`</summary>
 
 Use `<haxelib />` tags to include Haxe libraries:
 
@@ -144,8 +139,7 @@ You can also specify a version, if you prefer:
 </details>
 
 <details>
-<summary
-### `<section />`</summary>
+<summary`<section />`</summary>
 
 The `<section />` tag is used to group other tags together. This is usually most valuable when combined with "if" and/or "unless" logic:
 
@@ -157,8 +151,7 @@ The `<section />` tag is used to group other tags together. This is usually most
 </details>
 
 <details>
-<summary>
-### `<ndll />`</summary>
+<summary>`<ndll />`</summary>
 
 You can use `<ndll />` tags to include native libraries. These are usually located under an "ndll" directory, with additional directories based upon the target platform. Usually an `<ndll />` tag will be included as a part of an extension, and is rare to be used directly:
 
@@ -169,8 +162,7 @@ You can use `<ndll />` tags to include native libraries. These are usually locat
 </details>
 
 <details>
-<summary>
-### `<include />`</summary>
+<summary>`<include />`</summary>
 
 Use `<include />` tags to add the tags found in another project file, or to find an "include.xml" file in the target directory:
 
@@ -182,8 +174,7 @@ Use `<include />` tags to add the tags found in another project file, or to find
 </details>
 
 <details>
-<summary>
-### `<icon />`</summary>
+<summary>`<icon />`</summary>
 
 Use `<icon />` nodes to add icon files to your project. When the command-line tools request icons for a target platform, it will either use an exact size match you have provided, or it will attempt to find the closest match possible and resize. If you include an SVG vector icon, it should prefer this file over resizing bitmap files.
 
@@ -196,8 +187,7 @@ Use `<icon />` nodes to add icon files to your project. When the command-line to
 </details>
 
 <details>
-<summary>
-### `<assets />`</summary>
+<summary>`<assets />`</summary>
 
 Use asset nodes to add resources to your project, available using `lime.Assets`.
 
@@ -255,8 +245,7 @@ If an asset is specified as "template", it will not be copied/embedded as an ord
 </details>
 
 <details>
-<summary>
-### `<template />`</summary>
+<summary>`<template />`</summary>
 
 Use `<template />` tags to add paths which can override the templates used by the command-line tools.
 
@@ -274,8 +263,7 @@ Otherwise, you can override a single file like this:
 </details>
 
 <details>
-<summary>
-### `<haxeflag />`</summary>
+<summary>`<haxeflag />`</summary>
 
 Use `<haxeflag />` tags to add additional arguments in the Haxe compile process:
 
@@ -286,8 +274,7 @@ Use `<haxeflag />` tags to add additional arguments in the Haxe compile process:
 </details>
 
 <details>
-<summary>
-### `<haxedef />`</summary>
+<summary>`<haxedef />`</summary>
 
 Use `<haxedef />` tags to add Haxe defines (similar to using a `<haxeflag />` with "-D"):
 
@@ -298,8 +285,7 @@ Use `<haxedef />` tags to add Haxe defines (similar to using a `<haxeflag />` wi
 </details>
 
 <details>
-<summary>
-### `<setenv />`</summary>
+<summary>`<setenv />`</summary>
 
 Use `<setenv />` tags to set environment variables:
 
@@ -310,8 +296,7 @@ Use `<setenv />` tags to set environment variables:
 </details>
 
 <details>
-<summary>
-### `<java />`</summary>
+<summary>`<java />`</summary>
 
 Use `<java />` tags to add Java classes to the project when targeting Android:
 
@@ -322,8 +307,7 @@ Use `<java />` tags to add Java classes to the project when targeting Android:
 </details>
 
 <details>
-<summary>
-### `<certificate />`</summary>
+<summary>`<certificate />`</summary>
 
 Use `<certificate />` tags to add a keystore for release signing on certain platforms.
 
@@ -346,8 +330,7 @@ iOS does not use a certificate `path` and `password`, but instead uses a `team-i
 </details>
 
 <details>
-<summary>
-### `<config:ios />`</summary>
+<summary>`<config:ios />`</summary>
 
 Control iOS-specific values when compiling.
 
@@ -361,8 +344,7 @@ The `deployment` attribute can set the minimum iOS version you wish to target. T
 </details>
 
 <details>
-<summary>
-### `<config:android />`</summary>
+<summary>`<config:android />`</summary>
 
 Use `<config:android />` tags to set Android-specific values:
 
@@ -375,8 +357,7 @@ Use `<config:android />` tags to set Android-specific values:
 </details>
 
 <details>
-<summary>
-### `<architecture />`</summary>
+<summary>`<architecture />`</summary>
 
 Use `<architecture />` tags to set or exclude Android-specific architectures. These can be `ARMv7`, `ARMv6`, `ARMv5` and `X86`.
 
@@ -391,8 +372,7 @@ For example, if you want to enable `ARMv6` and disable `ARMv7` you would set the
 </details>
 
 <details>
-<summary>
-### `<dependency />`</summary>
+<summary>`<dependency />`</summary>
 
 Use `<dependency />` tags to specify native frameworks or references that are required to compile your project, as well as additional libraries you need copied.
 
@@ -403,8 +383,7 @@ Use `<dependency />` tags to specify native frameworks or references that are re
 </details>
 
 <details>
-<summary>
-### `<path />`</summary>
+<summary>`<path />`</summary>
 
 Use `<path />` tags to add directories to your system's PATH environment variable.
 
@@ -415,8 +394,7 @@ Use `<path />` tags to add directories to your system's PATH environment variabl
 </details>
 
 <details>
-<summary>
-### `<library />`</summary>
+<summary>`<library />`</summary>
 
 All assets go into the “default” library, but by adding `<library>` tags it is possible to modify the default library and also define additional libraries and load/unload them as needed.
 

--- a/_docs/project-files/xml-format.md
+++ b/_docs/project-files/xml-format.md
@@ -511,7 +511,7 @@ More to come.
 
 <details>
 <summary>&lt;swf /&gt;</summary>
-More to come.
+See “library“.
 </details>
 
 <details>

--- a/_docs/project-files/xml-format.md
+++ b/_docs/project-files/xml-format.md
@@ -70,7 +70,7 @@ If you create a haxelib, you can add "include.xml" to the top-level directory. T
 
 ## Common Tags (click to expand)
 <details>
-<summary>`<meta />`</summary>
+<summary><meta /></summary>
 
 Use `<meta />` tags to add information about your application, which usually will not affect how the application runs, but how it is identified to the target operating system or on an application store:
 
@@ -80,7 +80,7 @@ Use `<meta />` tags to add information about your application, which usually wil
 </details>
 
 <details>
-<summary>`<app />`</summary>
+<summary><app /></summary>
 
 The `<app />` tag sets values important to building your project, including the entry point (main class), the output file directory, or if you want to customize the executable filename or define a custom preloader for a web platform:
 
@@ -91,7 +91,7 @@ The `<app />` tag sets values important to building your project, including the 
 </details>
 
 <details>
-<summary>`<window />`</summary>
+<summary><window /></summary>
 
 You can use `<window />` tags to control how an application will be initialized. This includes the screen resolution and background color, as well as other options, such as whether hardware should be allowed or display mode flags.
 
@@ -109,7 +109,7 @@ The `orientation` value expects either "portrait" or "landscape" ... the default
 </details>
 
 <details>
-<summary>`<source />`</summary>
+<summary><source /></summary>
 
 Use `<source />` tags to add Haxe class paths:
 
@@ -122,7 +122,7 @@ If you are using `@:file`, `@:bitmap`, `@:sound` or `@:file` tags in your projec
 </details>
 
 <details>
-<summary>`<haxelib />`</summary>
+<summary><haxelib /></summary>
 
 Use `<haxelib />` tags to include Haxe libraries:
 
@@ -139,7 +139,7 @@ You can also specify a version, if you prefer:
 </details>
 
 <details>
-<summary`<section />`</summary>
+<summary><section /></summary>
 
 The `<section />` tag is used to group other tags together. This is usually most valuable when combined with "if" and/or "unless" logic:
 
@@ -151,7 +151,7 @@ The `<section />` tag is used to group other tags together. This is usually most
 </details>
 
 <details>
-<summary>`<ndll />`</summary>
+<summary><ndll /></summary>
 
 You can use `<ndll />` tags to include native libraries. These are usually located under an "ndll" directory, with additional directories based upon the target platform. Usually an `<ndll />` tag will be included as a part of an extension, and is rare to be used directly:
 
@@ -162,7 +162,7 @@ You can use `<ndll />` tags to include native libraries. These are usually locat
 </details>
 
 <details>
-<summary>`<include />`</summary>
+<summary><include /></summary>
 
 Use `<include />` tags to add the tags found in another project file, or to find an "include.xml" file in the target directory:
 
@@ -174,7 +174,7 @@ Use `<include />` tags to add the tags found in another project file, or to find
 </details>
 
 <details>
-<summary>`<icon />`</summary>
+<summary><icon /></summary>
 
 Use `<icon />` nodes to add icon files to your project. When the command-line tools request icons for a target platform, it will either use an exact size match you have provided, or it will attempt to find the closest match possible and resize. If you include an SVG vector icon, it should prefer this file over resizing bitmap files.
 
@@ -187,7 +187,7 @@ Use `<icon />` nodes to add icon files to your project. When the command-line to
 </details>
 
 <details>
-<summary>`<assets />`</summary>
+<summary><assets /></summary>
 
 Use asset nodes to add resources to your project, available using `lime.Assets`.
 
@@ -245,7 +245,7 @@ If an asset is specified as "template", it will not be copied/embedded as an ord
 </details>
 
 <details>
-<summary>`<template />`</summary>
+<summary><template /></summary>
 
 Use `<template />` tags to add paths which can override the templates used by the command-line tools.
 
@@ -263,7 +263,7 @@ Otherwise, you can override a single file like this:
 </details>
 
 <details>
-<summary>`<haxeflag />`</summary>
+<summary><haxeflag /></summary>
 
 Use `<haxeflag />` tags to add additional arguments in the Haxe compile process:
 
@@ -274,7 +274,7 @@ Use `<haxeflag />` tags to add additional arguments in the Haxe compile process:
 </details>
 
 <details>
-<summary>`<haxedef />`</summary>
+<summary><haxedef /></summary>
 
 Use `<haxedef />` tags to add Haxe defines (similar to using a `<haxeflag />` with "-D"):
 
@@ -285,7 +285,7 @@ Use `<haxedef />` tags to add Haxe defines (similar to using a `<haxeflag />` wi
 </details>
 
 <details>
-<summary>`<setenv />`</summary>
+<summary><setenv /></summary>
 
 Use `<setenv />` tags to set environment variables:
 
@@ -296,7 +296,7 @@ Use `<setenv />` tags to set environment variables:
 </details>
 
 <details>
-<summary>`<java />`</summary>
+<summary><java /></summary>
 
 Use `<java />` tags to add Java classes to the project when targeting Android:
 
@@ -307,7 +307,7 @@ Use `<java />` tags to add Java classes to the project when targeting Android:
 </details>
 
 <details>
-<summary>`<certificate />`</summary>
+<summary><certificate /></summary>
 
 Use `<certificate />` tags to add a keystore for release signing on certain platforms.
 
@@ -330,7 +330,7 @@ iOS does not use a certificate `path` and `password`, but instead uses a `team-i
 </details>
 
 <details>
-<summary>`<config:ios />`</summary>
+<summary><config:ios /></summary>
 
 Control iOS-specific values when compiling.
 
@@ -344,7 +344,7 @@ The `deployment` attribute can set the minimum iOS version you wish to target. T
 </details>
 
 <details>
-<summary>`<config:android />`</summary>
+<summary><config:android /></summary>
 
 Use `<config:android />` tags to set Android-specific values:
 
@@ -357,7 +357,7 @@ Use `<config:android />` tags to set Android-specific values:
 </details>
 
 <details>
-<summary>`<architecture />`</summary>
+<summary><architecture /></summary>
 
 Use `<architecture />` tags to set or exclude Android-specific architectures. These can be `ARMv7`, `ARMv6`, `ARMv5` and `X86`.
 
@@ -372,7 +372,7 @@ For example, if you want to enable `ARMv6` and disable `ARMv7` you would set the
 </details>
 
 <details>
-<summary>`<dependency />`</summary>
+<summary><dependency /></summary>
 
 Use `<dependency />` tags to specify native frameworks or references that are required to compile your project, as well as additional libraries you need copied.
 
@@ -383,7 +383,7 @@ Use `<dependency />` tags to specify native frameworks or references that are re
 </details>
 
 <details>
-<summary>`<path />`</summary>
+<summary><path /></summary>
 
 Use `<path />` tags to add directories to your system's PATH environment variable.
 
@@ -394,7 +394,7 @@ Use `<path />` tags to add directories to your system's PATH environment variabl
 </details>
 
 <details>
-<summary>`<library />`</summary>
+<summary><library /></summary>
 
 All assets go into the “default” library, but by adding `<library>` tags it is possible to modify the default library and also define additional libraries and load/unload them as needed.
 

--- a/_docs/project-files/xml-format.md
+++ b/_docs/project-files/xml-format.md
@@ -577,7 +577,7 @@ Same as “launchimage”.
 
 <details>
 <summary>&lt;ssl /&gt;</summary>
-More to come.
+Not implemented!!!
 </details>
 
 <details>
@@ -587,7 +587,10 @@ See “library“.
 
 <details>
 <summary>&lt;target /&gt;</summary>
-More to come.
+Lets you redefine build process for specific target by running custom haxelib command (might be useful if you want to use your own library for building your project, i.e. you are know what you're doing and you know how Lime build system works)
+	
+`<target name="customTarget" handler="yourHandler" />`
+
 </details>
 
 <details>

--- a/_docs/project-files/xml-format.md
+++ b/_docs/project-files/xml-format.md
@@ -258,7 +258,17 @@ More to come.
 
 <details>
 <summary>&lt;error /&gt;</summary>
-More to come.
+
+Logs error with `lime.utils.Log.error()`, which by default throws `value` message and stops compilation (if `lime.utils.Log.throwErrors` is set to `true`)
+
+Example:
+
+```
+<section if="html5">
+	<error value="html5 isn't supported!" />
+</section>
+```
+
 </details>
 
 <details>

--- a/_docs/project-files/xml-format.md
+++ b/_docs/project-files/xml-format.md
@@ -70,7 +70,7 @@ If you create a haxelib, you can add "include.xml" to the top-level directory. T
 
 ## Common Tags (click to expand)
 <details>
-<summary>&gt;meta /&lt;</summary>
+<summary>&lt;meta /&gt;</summary>
 
 Use `<meta />` tags to add information about your application, which usually will not affect how the application runs, but how it is identified to the target operating system or on an application store:
 
@@ -80,7 +80,7 @@ Use `<meta />` tags to add information about your application, which usually wil
 </details>
 
 <details>
-<summary><app /></summary>
+<summary>&lt;app /&gt;</summary>
 
 The `<app />` tag sets values important to building your project, including the entry point (main class), the output file directory, or if you want to customize the executable filename or define a custom preloader for a web platform:
 
@@ -91,7 +91,7 @@ The `<app />` tag sets values important to building your project, including the 
 </details>
 
 <details>
-<summary><window /></summary>
+<summary>&lt;window /&gt;</summary>
 
 You can use `<window />` tags to control how an application will be initialized. This includes the screen resolution and background color, as well as other options, such as whether hardware should be allowed or display mode flags.
 
@@ -109,7 +109,7 @@ The `orientation` value expects either "portrait" or "landscape" ... the default
 </details>
 
 <details>
-<summary><source /></summary>
+<summary>&lt;source /&gt;</summary>
 
 Use `<source />` tags to add Haxe class paths:
 
@@ -122,7 +122,7 @@ If you are using `@:file`, `@:bitmap`, `@:sound` or `@:file` tags in your projec
 </details>
 
 <details>
-<summary><haxelib /></summary>
+<summary>&lt;haxelib /&gt;</summary>
 
 Use `<haxelib />` tags to include Haxe libraries:
 
@@ -139,7 +139,7 @@ You can also specify a version, if you prefer:
 </details>
 
 <details>
-<summary><section /></summary>
+<summary>&lt;section /&gt;</summary>
 
 The `<section />` tag is used to group other tags together. This is usually most valuable when combined with "if" and/or "unless" logic:
 
@@ -151,7 +151,7 @@ The `<section />` tag is used to group other tags together. This is usually most
 </details>
 
 <details>
-<summary><ndll /></summary>
+<summary>&lt;ndll /&gt;</summary>
 
 You can use `<ndll />` tags to include native libraries. These are usually located under an "ndll" directory, with additional directories based upon the target platform. Usually an `<ndll />` tag will be included as a part of an extension, and is rare to be used directly:
 
@@ -162,7 +162,7 @@ You can use `<ndll />` tags to include native libraries. These are usually locat
 </details>
 
 <details>
-<summary><include /></summary>
+<summary>&lt;include /&gt;</summary>
 
 Use `<include />` tags to add the tags found in another project file, or to find an "include.xml" file in the target directory:
 
@@ -174,7 +174,7 @@ Use `<include />` tags to add the tags found in another project file, or to find
 </details>
 
 <details>
-<summary><icon /></summary>
+<summary>&lt;icon /&gt;</summary>
 
 Use `<icon />` nodes to add icon files to your project. When the command-line tools request icons for a target platform, it will either use an exact size match you have provided, or it will attempt to find the closest match possible and resize. If you include an SVG vector icon, it should prefer this file over resizing bitmap files.
 
@@ -187,7 +187,7 @@ Use `<icon />` nodes to add icon files to your project. When the command-line to
 </details>
 
 <details>
-<summary><assets /></summary>
+<summary>&lt;assets /&gt;</summary>
 
 Use asset nodes to add resources to your project, available using `lime.Assets`.
 
@@ -245,7 +245,7 @@ If an asset is specified as "template", it will not be copied/embedded as an ord
 </details>
 
 <details>
-<summary><template /></summary>
+<summary>&lt;template /&gt;</summary>
 
 Use `<template />` tags to add paths which can override the templates used by the command-line tools.
 
@@ -263,7 +263,7 @@ Otherwise, you can override a single file like this:
 </details>
 
 <details>
-<summary><haxeflag /></summary>
+<summary>&lt;haxeflag /&gt;</summary>
 
 Use `<haxeflag />` tags to add additional arguments in the Haxe compile process:
 
@@ -274,7 +274,7 @@ Use `<haxeflag />` tags to add additional arguments in the Haxe compile process:
 </details>
 
 <details>
-<summary><haxedef /></summary>
+<summary>&lt;haxedef /&gt;</summary>
 
 Use `<haxedef />` tags to add Haxe defines (similar to using a `<haxeflag />` with "-D"):
 
@@ -285,7 +285,7 @@ Use `<haxedef />` tags to add Haxe defines (similar to using a `<haxeflag />` wi
 </details>
 
 <details>
-<summary><setenv /></summary>
+<summary>&lt;setenv /&gt;</summary>
 
 Use `<setenv />` tags to set environment variables:
 
@@ -296,7 +296,7 @@ Use `<setenv />` tags to set environment variables:
 </details>
 
 <details>
-<summary><java /></summary>
+<summary>&lt;java /&gt;</summary>
 
 Use `<java />` tags to add Java classes to the project when targeting Android:
 
@@ -307,7 +307,7 @@ Use `<java />` tags to add Java classes to the project when targeting Android:
 </details>
 
 <details>
-<summary><certificate /></summary>
+<summary>&lt;certificate /&gt;</summary>
 
 Use `<certificate />` tags to add a keystore for release signing on certain platforms.
 
@@ -330,7 +330,7 @@ iOS does not use a certificate `path` and `password`, but instead uses a `team-i
 </details>
 
 <details>
-<summary><config:ios /></summary>
+<summary>&lt;config:ios /&gt;</summary>
 
 Control iOS-specific values when compiling.
 
@@ -344,7 +344,7 @@ The `deployment` attribute can set the minimum iOS version you wish to target. T
 </details>
 
 <details>
-<summary><config:android /></summary>
+<summary>&lt;config:android /&gt;</summary>
 
 Use `<config:android />` tags to set Android-specific values:
 
@@ -357,7 +357,7 @@ Use `<config:android />` tags to set Android-specific values:
 </details>
 
 <details>
-<summary><architecture /></summary>
+<summary>&lt;architecture /&gt;</summary>
 
 Use `<architecture />` tags to set or exclude Android-specific architectures. These can be `ARMv7`, `ARMv6`, `ARMv5` and `X86`.
 
@@ -372,7 +372,7 @@ For example, if you want to enable `ARMv6` and disable `ARMv7` you would set the
 </details>
 
 <details>
-<summary><dependency /></summary>
+<summary>&lt;dependency /&gt;</summary>
 
 Use `<dependency />` tags to specify native frameworks or references that are required to compile your project, as well as additional libraries you need copied.
 
@@ -383,7 +383,7 @@ Use `<dependency />` tags to specify native frameworks or references that are re
 </details>
 
 <details>
-<summary><path /></summary>
+<summary>&lt;path /&gt;</summary>
 
 Use `<path />` tags to add directories to your system's PATH environment variable.
 
@@ -394,7 +394,7 @@ Use `<path />` tags to add directories to your system's PATH environment variabl
 </details>
 
 <details>
-<summary><library /></summary>
+<summary>&lt;library /&gt;</summary>
 
 All assets go into the “default” library, but by adding `<library>` tags it is possible to modify the default library and also define additional libraries and load/unload them as needed.
 

--- a/_docs/project-files/xml-format.md
+++ b/_docs/project-files/xml-format.md
@@ -544,12 +544,12 @@ More to come.
 
 <details>
 <summary>&lt;undefine /&gt;</summary>
-See entry for `<define />`.
+See entry for `&lt;define /&gt;`.
 </details>
 
 <details>
 <summary>&lt;unset /&gt;</summary>
-See entry for `<set />`.
+See entry for `&lt;set /&gt;`.
 </details>
 
 <details>

--- a/_docs/project-files/xml-format.md
+++ b/_docs/project-files/xml-format.md
@@ -321,7 +321,7 @@ Assets.loadLibrary ("default").onComplete (function (library) {
 });
 ```
 
-####Using Additional Asset Libraries
+**Using Additional Asset Libraries**
 
 You can easily add assets to libraries other than the “default” library. These are not preloaded by default, unless you add: `<library name="myOtherLibrary" preload="true" />`
 

--- a/_docs/project-files/xml-format.md
+++ b/_docs/project-files/xml-format.md
@@ -68,17 +68,18 @@ You can include more than one copy of each tag, so do not worry about putting it
 
 If you create a haxelib, you can add "include.xml" to the top-level directory. The build tools will automatically add the contents of the file to the user's project. You can use this to add binary dependencies, additional classpaths, etc.
 
-## Common Tags
-
-### `<meta />`
+## Common Tags (click to expand)
+<details>
+<summary>### `<meta />`</summary>
 
 Use `<meta />` tags to add information about your application, which usually will not affect how the application runs, but how it is identified to the target operating system or on an application store:
 
 ```xml
 <meta title="My Application" package="com.example.myapplication" version="1.0.0" company="My Company" />
 ```
-
-### `<app />`
+</details>
+<details>
+<summary>### `<app />`</summary>
 
 The `<app />` tag sets values important to building your project, including the entry point (main class), the output file directory, or if you want to customize the executable filename or define a custom preloader for a web platform:
 
@@ -86,8 +87,9 @@ The `<app />` tag sets values important to building your project, including the 
 <app main="com.example.MyApplication" file="MyApplication" path="Export" preloader="CustomPreloader" />
 <app swf-version="11" />
 ```
-
-### `<window />`
+</details>
+<details>
+<summary>### `<window />`</summary>
 
 You can use `<window />` tags to control how an application will be initialized. This includes the screen resolution and background color, as well as other options, such as whether hardware should be allowed or display mode flags.
 
@@ -102,7 +104,9 @@ By default, mobile platforms use a window width and height of 0, which is a spec
 
 The `orientation` value expects either "portrait" or "landscape" ... the default is "auto" which allows the operating system to decide which orientation to use.
 
-### `<source />`
+</details>
+<details>
+<summary>### `<source />`</summary>
 
 Use `<source />` tags to add Haxe class paths:
 
@@ -112,7 +116,9 @@ Use `<source />` tags to add Haxe class paths:
 
 If you are using `@:file`, `@:bitmap`, `@:sound` or `@:file` tags in your project, be sure that the asset files are available within your Haxe source paths.
 
-### `<haxelib />`
+</details>
+<details>
+<summary>### `<haxelib />`</summary>
 
 Use `<haxelib />` tags to include Haxe libraries:
 
@@ -126,7 +132,9 @@ You can also specify a version, if you prefer:
 <haxelib name="actuate" version="1.0.0" />
 ```
 
-### `<section />`
+</details>
+<details>
+<summary>### `<section />`</summary>
 
 The `<section />` tag is used to group other tags together. This is usually most valuable when combined with "if" and/or "unless" logic:
 
@@ -135,8 +143,9 @@ The `<section />` tag is used to group other tags together. This is usually most
 	<source path="extra/src/html5" />
 </section>
 ```
-
-### `<ndll />`
+</details>
+<details>
+<summary>### `<ndll />`</summary>
 
 You can use `<ndll />` tags to include native libraries. These are usually located under an "ndll" directory, with additional directories based upon the target platform. Usually an `<ndll />` tag will be included as a part of an extension, and is rare to be used directly:
 
@@ -144,7 +153,9 @@ You can use `<ndll />` tags to include native libraries. These are usually locat
 <ndll name="std" haxelib="hxcpp" />
 ```
 
-### `<include />`
+</details>
+<details>
+<summary>### `<include />`</summary>
 
 Use `<include />` tags to add the tags found in another project file, or to find an "include.xml" file in the target directory:
 
@@ -153,7 +164,9 @@ Use `<include />` tags to add the tags found in another project file, or to find
 <include path="to/shared/library" />
 ```
 
-### `<icon />`
+</details>
+<details>
+<summary>### `<icon />`</summary>
 
 Use `<icon />` nodes to add icon files to your project. When the command-line tools request icons for a target platform, it will either use an exact size match you have provided, or it will attempt to find the closest match possible and resize. If you include an SVG vector icon, it should prefer this file over resizing bitmap files.
 
@@ -163,7 +176,9 @@ Use `<icon />` nodes to add icon files to your project. When the command-line to
 <icon path="icon.svg" />
 ```
 
-### `<assets />`
+</details>
+<details>
+<summary>### `<assets />`</summary>
 
 Use asset nodes to add resources to your project, available using `lime.Assets`.
 
@@ -217,9 +232,10 @@ If an asset is specified as "template", it will not be copied/embedded as an ord
 </assets>
 ```
 
-## Additional Tags
 
-### `<template />`
+</details>
+<details>
+<summary>### `<template />`</summary>
 
 Use `<template />` tags to add paths which can override the templates used by the command-line tools.
 
@@ -234,8 +250,9 @@ Otherwise, you can override a single file like this:
 ```xml
 <template path="Assets/index.html" rename="index.html" />
 ```
-
-### `<haxeflag />`
+</details>
+<details>
+<summary>### `<haxeflag />`</summary>
 
 Use `<haxeflag />` tags to add additional arguments in the Haxe compile process:
 
@@ -243,7 +260,9 @@ Use `<haxeflag />` tags to add additional arguments in the Haxe compile process:
 <haxeflag name="-dce" value="std" />
 ```
 
-### `<haxedef />`
+</details>
+<details>
+<summary>### `<haxedef />`</summary>
 
 Use `<haxedef />` tags to add Haxe defines (similar to using a `<haxeflag />` with "-D"):
 
@@ -251,7 +270,9 @@ Use `<haxedef />` tags to add Haxe defines (similar to using a `<haxeflag />` wi
 <haxedef name="define" />
 ```
 
-### `<setenv />`
+</details>
+<details>
+<summary>### `<setenv />`</summary>
 
 Use `<setenv />` tags to set environment variables:
 
@@ -259,7 +280,9 @@ Use `<setenv />` tags to set environment variables:
 <setenv name="GLOBAL_DEFINE" />
 ```
 
-### `<java />`
+</details>
+<details>
+<summary>### `<java />`</summary>
 
 Use `<java />` tags to add Java classes to the project when targeting Android:
 
@@ -267,7 +290,9 @@ Use `<java />` tags to add Java classes to the project when targeting Android:
 <java path="to/classes" />
 ```
 
-### `<certificate />`
+</details>
+<details>
+<summary>### `<certificate />`</summary>
 
 Use `<certificate />` tags to add a keystore for release signing on certain platforms.
 
@@ -287,7 +312,9 @@ iOS does not use a certificate `path` and `password`, but instead uses a `team-i
 <certificate team-id="SK12FH34" />
 ```
 
-### `<config:ios />`
+</details>
+<details>
+<summary>### `<config:ios />`</summary>
 
 Control iOS-specific values when compiling.
 
@@ -298,7 +325,9 @@ The `deployment` attribute can set the minimum iOS version you wish to target. T
 <config:ios prerendered-icon="false" />
 ```
 
-### `<config:android />`
+</details>
+<details>
+<summary>### `<config:android />`</summary>
 
 Use `<config:android />` tags to set Android-specific values:
 
@@ -308,7 +337,9 @@ Use `<config:android />` tags to set Android-specific values:
 <config:android target-sdk-version="16" />
 ```
 
-### `<architecture />`
+</details>
+<details>
+<summary>### `<architecture />`</summary>
 
 Use `<architecture />` tags to set or exclude Android-specific architectures. These can be `ARMv7`, `ARMv6`, `ARMv5` and `X86`.
 
@@ -320,7 +351,9 @@ For example, if you want to enable `ARMv6` and disable `ARMv7` you would set the
 <architecture name="armv6" exclude="armv7" if="android" />
 ```
 
-### `<dependency />`
+</details>
+<details>
+<summary>### `<dependency />`</summary>
 
 Use `<dependency />` tags to specify native frameworks or references that are required to compile your project, as well as additional libraries you need copied.
 
@@ -328,10 +361,47 @@ Use `<dependency />` tags to specify native frameworks or references that are re
 <dependency name="GameKit.framework" if="ios" />
 ```
 
-### `<path />`
+</details>
+<details>
+<summary>### `<path />`</summary>
 
 Use `<path />` tags to add directories to your system's PATH environment variable.
 
 ```xml
 <path value="path/to/add/to/system/PATH" />
 ```
+
+</details>
+<details>
+<summary>### `<library />`</summary>
+
+All assets go into the “default” library, but by adding `<library>` tags it is possible to modify the default library and also define additional libraries and load/unload them as needed.
+
+To disable preloading on the default library:
+
+`<library name="default" preload="false" />`
+
+To load assets at runtime,:
+
+```
+Assets.loadLibrary ("default").onComplete (function (library) {
+
+    var bitmapData = Assets.getBitmapData ("default:image.png");
+    // or
+    var bitmapData = Assets.getBitmapData ("image.png");
+    // "default:" prefix is implied, if no library prefix is included
+});
+```
+
+####Using Additional Asset Libraries
+
+You can easily add assets to libraries other than the “default” library. These are not preloaded by default, unless you add: `<library name="myOtherLibrary" preload="true" />`
+
+Then to have certain assets allocated to the above library:
+`<assets path="assets/other" library="myOtherLibrary" />`
+
+Be sure to specify the correct library when retrieving the assets in your code. See the above example for using the library prefix.
+
+You can also use `Assets.unloadLibrary` when you are doing using those resources.
+
+</details>

--- a/_docs/project-files/xml-format.md
+++ b/_docs/project-files/xml-format.md
@@ -484,7 +484,7 @@ Use `<path />` tags to add directories to your system's PATH environment variabl
 
 <details>
 <summary>&lt;postbuild /&gt;</summary>
-Lets you set post build command, which could be Haxe code (will be interpeted by the Haxe interpreter), file open command or console command:
+Lets you set post build commands, which could be Haxe code (will be interpeted by the Haxe interpreter), run file command or console command:
 	
 ```
 <postbuild haxe="Haxe code"/>
@@ -497,7 +497,14 @@ Lets you set post build command, which could be Haxe code (will be interpeted by
 
 <details>
 <summary>&lt;prebuild /&gt;</summary>
-More to come.
+Lets you set pre build commands, which could be Haxe code (will be interpeted by the Haxe interpreter), run file command or console command:
+	
+```
+<prebuild haxe="Haxe code"/>
+<prebuild open="file to run"/>
+<prebuild command="command to run"/>
+<prebuild cmd="command to run"/>
+```
 </details>
 
 <details>

--- a/_docs/project-files/xml-format.md
+++ b/_docs/project-files/xml-format.md
@@ -177,9 +177,42 @@ iOS does not use a certificate `path` and `password`, but instead uses a `team-i
 </details>
 
 <details>
-<summary>&lt;config:android /&gt;</summary>
+<summary>&lt;classpath /&gt;</summary>
+Same as “source”.
+</details>
 
-Use `<config:android />` tags to set Android-specific values:
+<details>
+<summary>&lt;compilerflag /&gt;</summary>
+Same as "haxeflag".
+</details>
+
+<details>
+<summary>&lt;config /&gt;</summary>
+Use `<config />` tags to set platform-specific values. These targets are currently supported:
+- air
+- android
+- blackberry
+- console-pc
+- firefox
+- flash
+- html5
+- ios
+- linux
+- mac
+- ps3
+- ps4
+- tizen
+- vita
+- windows
+- webos
+- wiiu
+- xbox1
+- emscripten
+- tvos
+
+**One must append a suffix to the tag depending on the platform. **
+
+For example, use `<config:android />` tags to set Android-specific values:
 
 ```xml
 <config:android install-location="preferExternal" />
@@ -187,14 +220,7 @@ Use `<config:android />` tags to set Android-specific values:
 <config:android target-sdk-version="16" />
 ```
 
-</details>
-
-<details>
-<summary>&lt;config:ios /&gt;</summary>
-
-Control iOS-specific values when compiling.
-
-The `deployment` attribute can set the minimum iOS version you wish to target. The `prerendered-icon` attribute can help control the style of your icon.
+Use `<config:ios />` tags to set iOS-specific values when compiling. The `deployment` attribute can set the minimum iOS version you wish to target. The `prerendered-icon` attribute can help control the style of your icon.
 
 ```xml
 <config:ios deployment="5.1" />
@@ -223,6 +249,16 @@ Use `<dependency />` tags to specify native frameworks or references that are re
 <dependency name="GameKit.framework" if="ios" />
 ```
 
+</details>
+
+<details>
+<summary>&lt;echo /&gt;</summary>
+More to come.
+</details>
+
+<details>
+<summary>&lt;error /&gt;</summary>
+More to come.
 </details>
 
 <details>
@@ -301,6 +337,21 @@ Use `<java />` tags to add Java classes to the project when targeting Android:
 </details>
 
 <details>
+<summary>&lt;language /&gt;</summary>
+More to come.
+</details>
+
+<details>
+<summary>&lt;launchimage /&gt;</summary>
+More to come.
+</details>
+
+<details>
+<summary>&lt;launchstoryboard /&gt;</summary>
+More to come.
+</details>
+
+<details>
 <summary>&lt;library /&gt;</summary>
 
 All assets go into the “default” library, but by adding `<library>` tags it is possible to modify the default library and also define additional libraries and load/unload them as needed.
@@ -311,7 +362,7 @@ To disable preloading on the default library:
 
 To load assets at runtime,:
 
-```
+```haxe
 Assets.loadLibrary ("default").onComplete (function (library) {
 
     var bitmapData = Assets.getBitmapData ("default:image.png");
@@ -335,6 +386,11 @@ You can also use `Assets.unloadLibrary` when you are doing using those resources
 </details>
 
 <details>
+<summary>&lt;log /&gt;</summary>
+More to come.
+</details>
+
+<details>
 <summary>&lt;meta /&gt;</summary>
 
 Use `<meta />` tags to add information about your application, which usually will not affect how the application runs, but how it is identified to the target operating system or on an application store:
@@ -342,6 +398,11 @@ Use `<meta />` tags to add information about your application, which usually wil
 ```xml
 <meta title="My Application" package="com.example.myapplication" version="1.0.0" company="My Company" />
 ```
+</details>
+
+<details>
+<summary>&lt;module /&gt;</summary>
+More to come.
 </details>
 
 <details>
@@ -356,6 +417,11 @@ You can use `<ndll />` tags to include native libraries. These are usually locat
 </details>
 
 <details>
+<summary>&lt;output /&gt;</summary>
+More to come.
+</details>
+
+<details>
 <summary>&lt;path /&gt;</summary>
 
 Use `<path />` tags to add directories to your system's PATH environment variable.
@@ -364,6 +430,26 @@ Use `<path />` tags to add directories to your system's PATH environment variabl
 <path value="path/to/add/to/system/PATH" />
 ```
 
+</details>
+
+<details>
+<summary>&lt;postbuild /&gt;</summary>
+More to come.
+</details>
+
+<details>
+<summary>&lt;prebuild /&gt;</summary>
+More to come.
+</details>
+
+<details>
+<summary>&lt;preloader /&gt;</summary>
+More to come.
+</details>
+
+<details>
+<summary>&lt;sample /&gt;</summary>
+More to come.
 </details>
 
 <details>
@@ -414,6 +500,26 @@ If you are using `@:file`, `@:bitmap`, `@:sound` or `@:file` tags in your projec
 </details>
 
 <details>
+<summary>&lt;splashscreen /&gt;</summary>
+Same as “launchimage”.
+</details>
+
+<details>
+<summary>&lt;ssl /&gt;</summary>
+More to come.
+</details>
+
+<details>
+<summary>&lt;swf /&gt;</summary>
+More to come.
+</details>
+
+<details>
+<summary>&lt;target /&gt;</summary>
+More to come.
+</details>
+
+<details>
 <summary>&lt;template /&gt;</summary>
 
 Use `<template />` tags to add paths which can override the templates used by the command-line tools.
@@ -429,6 +535,21 @@ Otherwise, you can override a single file like this:
 ```xml
 <template path="Assets/index.html" rename="index.php" />
 ```
+</details>
+
+<details>
+<summary>&lt;templatepath /&gt;</summary>
+More to come.
+</details>
+
+<details>
+<summary>&lt;undefine /&gt;</summary>
+More to come.
+</details>
+
+<details>
+<summary>&lt;unset /&gt;</summary>
+More to come.
 </details>
 
 <details>

--- a/_docs/project-files/xml-format.md
+++ b/_docs/project-files/xml-format.md
@@ -253,7 +253,7 @@ Use `<dependency />` tags to specify native frameworks or references that are re
 
 <details>
 <summary>&lt;echo /&gt;</summary>
-Prints specified message to the console:
+Prints a specified message to the console.
 
 ```
 <echo value="Some output message" />
@@ -264,7 +264,7 @@ Prints specified message to the console:
 <details>
 <summary>&lt;error /&gt;</summary>
 
-Logs error with `lime.utils.Log.error()`, which by default throws `value` message and stops compilation (if `lime.utils.Log.throwErrors` is set to `true`)
+Logs an error with `lime.utils.Log.error()` which by default throws `value` message and stops compilation (if `lime.utils.Log.throwErrors` is set to `true`).
 
 Example:
 
@@ -354,7 +354,7 @@ Use `<java />` tags to add Java classes to the project when targeting Android:
 <details>
 <summary>&lt;language /&gt;</summary>
 
-Adds language to the list of supported languages (by default the list is empty)
+Adds a language to the list of supported languages (by default the list is empty).
 
 `<language name="en-US" />`
 
@@ -370,7 +370,7 @@ Sets the path to launch image of the app (image which will be shown at applicati
 
 <details>
 <summary>&lt;launchstoryboard /&gt;</summary>
-Sets launch screen storyboard (useful only for iOS development)
+Sets the launch screen storyboard (useful only for iOS development).
 
 `<launchstoryboard path="image.png" />`
 
@@ -378,7 +378,7 @@ or
 
 `<launchstoryboard name="image.png" />`
 
-You can also use `template` for it (will be documented in the future)
+You can also use `template` for this purpose (to be documented in the future).
 
 </details>
 
@@ -418,7 +418,7 @@ You can also use `Assets.unloadLibrary` when you are doing using those resources
 
 <details>
 <summary>&lt;log /&gt;</summary>
-Logs error (see "error"), warning or info message.
+Logs an error (see "error"), warning or info message.
 
 Examples:
 
@@ -484,7 +484,7 @@ Use `<path />` tags to add directories to your system's PATH environment variabl
 
 <details>
 <summary>&lt;postbuild /&gt;</summary>
-Lets you set post build commands, which could be Haxe code (will be interpeted by the Haxe interpreter), run file command or console command:
+Lets you set post-build commands such as Haxe code (interpeted by the Haxe interpreter), a run file command, or a console command.
 	
 ```
 <postbuild haxe="Haxe code"/>
@@ -497,7 +497,7 @@ Lets you set post build commands, which could be Haxe code (will be interpeted b
 
 <details>
 <summary>&lt;prebuild /&gt;</summary>
-Lets you set pre build commands, which could be Haxe code (will be interpeted by the Haxe interpreter), run file command or console command:
+Lets you set pre-build commands such as Haxe code (interpeted by the Haxe interpreter), a run file command, or a console command:
 	
 ```
 <prebuild haxe="Haxe code"/>
@@ -587,7 +587,7 @@ See “library“.
 
 <details>
 <summary>&lt;target /&gt;</summary>
-Lets you redefine build process for specific target by running custom haxelib command (might be useful if you want to use your own library for building your project, i.e. you are know what you're doing and you know how Lime build system works)
+Lets you redefine the build process for a specific target by running a custom haxelib command. This might be useful if you want to use your own library for building your project, i.e. you know what you're doing and you know how the Lime build system works.
 	
 `<target name="customTarget" handler="yourHandler" />`
 
@@ -613,7 +613,7 @@ Otherwise, you can override a single file like this:
 
 <details>
 <summary>&lt;templatepath /&gt;</summary>
-See "template"
+See “template”.
 
 `<templatepath name="path"/>`
 
@@ -621,7 +621,7 @@ See "template"
 
 <details>
 <summary>&lt;undefine /&gt;</summary>
-Resets previously defined flag. See entry for `&lt;define /&gt;`.
+Unsets a previously defined flag. See entry for `&lt;define /&gt;`.
 
 ```
 <undefine name="red" />
@@ -632,7 +632,7 @@ Resets previously defined flag. See entry for `&lt;define /&gt;`.
 <details>
 <summary>&lt;unset /&gt;</summary>
 
-Unsets previously defined value. See entry for `<set />`.
+Unsets a previously set value. See entry for `<set />`.
 	
 ```
 <set name="red" value="0xff0000" />

--- a/_docs/project-files/xml-format.md
+++ b/_docs/project-files/xml-format.md
@@ -613,17 +613,30 @@ Otherwise, you can override a single file like this:
 
 <details>
 <summary>&lt;templatepath /&gt;</summary>
-More to come.
+See "template"
+
+`<templatepath name="path"/>`
+
 </details>
 
 <details>
 <summary>&lt;undefine /&gt;</summary>
-More to come.
+Resets previously defined flag
+
+```
+<undefine name="red" />
+```
+
 </details>
 
 <details>
 <summary>&lt;unset /&gt;</summary>
-More to come.
+Unsets previously defined value:
+	
+```
+<set name="red" value="0xff0000" />
+<unset name="red" />
+```
 </details>
 
 <details>

--- a/_docs/project-files/xml-format.md
+++ b/_docs/project-files/xml-format.md
@@ -484,7 +484,15 @@ Use `<path />` tags to add directories to your system's PATH environment variabl
 
 <details>
 <summary>&lt;postbuild /&gt;</summary>
-More to come.
+Lets you set post build command, which could be Haxe code (will be interpeted by the Haxe interpreter), file open command or console command:
+	
+```
+<postbuild haxe="Haxe code"/>
+<postbuild open="file to run"/>
+<postbuild command="command to run"/>
+<postbuild cmd="command to run"/>
+```
+
 </details>
 
 <details>

--- a/_docs/project-files/xml-format.md
+++ b/_docs/project-files/xml-format.md
@@ -460,7 +460,15 @@ You can use `<ndll />` tags to include native libraries. These are usually locat
 
 <details>
 <summary>&lt;output /&gt;</summary>
-More to come.
+Deprecated!!!
+Can be used for setting app file name, app path and app swf-version:
+
+```
+<output name="app file name" />
+<output name="app path" />
+<output swf-version="11" />
+```
+
 </details>
 
 <details>

--- a/_docs/project-files/xml-format.md
+++ b/_docs/project-files/xml-format.md
@@ -70,7 +70,7 @@ If you create a haxelib, you can add "include.xml" to the top-level directory. T
 
 ## Common Tags (click to expand)
 <details>
-<summary><meta /></summary>
+<summary>&gt;meta /&lt;</summary>
 
 Use `<meta />` tags to add information about your application, which usually will not affect how the application runs, but how it is identified to the target operating system or on an application store:
 

--- a/_docs/project-files/xml-format.md
+++ b/_docs/project-files/xml-format.md
@@ -70,7 +70,8 @@ If you create a haxelib, you can add "include.xml" to the top-level directory. T
 
 ## Common Tags (click to expand)
 <details>
-<summary>### `<meta />`</summary>
+<summary>
+### `<meta />`</summary>
 
 Use `<meta />` tags to add information about your application, which usually will not affect how the application runs, but how it is identified to the target operating system or on an application store:
 
@@ -78,8 +79,10 @@ Use `<meta />` tags to add information about your application, which usually wil
 <meta title="My Application" package="com.example.myapplication" version="1.0.0" company="My Company" />
 ```
 </details>
+
 <details>
-<summary>### `<app />`</summary>
+<summary>
+### `<app />`</summary>
 
 The `<app />` tag sets values important to building your project, including the entry point (main class), the output file directory, or if you want to customize the executable filename or define a custom preloader for a web platform:
 
@@ -88,8 +91,10 @@ The `<app />` tag sets values important to building your project, including the 
 <app swf-version="11" />
 ```
 </details>
+
 <details>
-<summary>### `<window />`</summary>
+<summary>
+### `<window />`</summary>
 
 You can use `<window />` tags to control how an application will be initialized. This includes the screen resolution and background color, as well as other options, such as whether hardware should be allowed or display mode flags.
 
@@ -105,8 +110,10 @@ By default, mobile platforms use a window width and height of 0, which is a spec
 The `orientation` value expects either "portrait" or "landscape" ... the default is "auto" which allows the operating system to decide which orientation to use.
 
 </details>
+
 <details>
-<summary>### `<source />`</summary>
+<summary>
+### `<source />`</summary>
 
 Use `<source />` tags to add Haxe class paths:
 
@@ -117,8 +124,10 @@ Use `<source />` tags to add Haxe class paths:
 If you are using `@:file`, `@:bitmap`, `@:sound` or `@:file` tags in your project, be sure that the asset files are available within your Haxe source paths.
 
 </details>
+
 <details>
-<summary>### `<haxelib />`</summary>
+<summary>
+### `<haxelib />`</summary>
 
 Use `<haxelib />` tags to include Haxe libraries:
 
@@ -133,8 +142,10 @@ You can also specify a version, if you prefer:
 ```
 
 </details>
+
 <details>
-<summary>### `<section />`</summary>
+<summary
+### `<section />`</summary>
 
 The `<section />` tag is used to group other tags together. This is usually most valuable when combined with "if" and/or "unless" logic:
 
@@ -144,8 +155,10 @@ The `<section />` tag is used to group other tags together. This is usually most
 </section>
 ```
 </details>
+
 <details>
-<summary>### `<ndll />`</summary>
+<summary>
+### `<ndll />`</summary>
 
 You can use `<ndll />` tags to include native libraries. These are usually located under an "ndll" directory, with additional directories based upon the target platform. Usually an `<ndll />` tag will be included as a part of an extension, and is rare to be used directly:
 
@@ -154,8 +167,10 @@ You can use `<ndll />` tags to include native libraries. These are usually locat
 ```
 
 </details>
+
 <details>
-<summary>### `<include />`</summary>
+<summary>
+### `<include />`</summary>
 
 Use `<include />` tags to add the tags found in another project file, or to find an "include.xml" file in the target directory:
 
@@ -165,8 +180,10 @@ Use `<include />` tags to add the tags found in another project file, or to find
 ```
 
 </details>
+
 <details>
-<summary>### `<icon />`</summary>
+<summary>
+### `<icon />`</summary>
 
 Use `<icon />` nodes to add icon files to your project. When the command-line tools request icons for a target platform, it will either use an exact size match you have provided, or it will attempt to find the closest match possible and resize. If you include an SVG vector icon, it should prefer this file over resizing bitmap files.
 
@@ -177,8 +194,10 @@ Use `<icon />` nodes to add icon files to your project. When the command-line to
 ```
 
 </details>
+
 <details>
-<summary>### `<assets />`</summary>
+<summary>
+### `<assets />`</summary>
 
 Use asset nodes to add resources to your project, available using `lime.Assets`.
 
@@ -234,8 +253,10 @@ If an asset is specified as "template", it will not be copied/embedded as an ord
 
 
 </details>
+
 <details>
-<summary>### `<template />`</summary>
+<summary>
+### `<template />`</summary>
 
 Use `<template />` tags to add paths which can override the templates used by the command-line tools.
 
@@ -251,8 +272,10 @@ Otherwise, you can override a single file like this:
 <template path="Assets/index.html" rename="index.html" />
 ```
 </details>
+
 <details>
-<summary>### `<haxeflag />`</summary>
+<summary>
+### `<haxeflag />`</summary>
 
 Use `<haxeflag />` tags to add additional arguments in the Haxe compile process:
 
@@ -261,8 +284,10 @@ Use `<haxeflag />` tags to add additional arguments in the Haxe compile process:
 ```
 
 </details>
+
 <details>
-<summary>### `<haxedef />`</summary>
+<summary>
+### `<haxedef />`</summary>
 
 Use `<haxedef />` tags to add Haxe defines (similar to using a `<haxeflag />` with "-D"):
 
@@ -271,8 +296,10 @@ Use `<haxedef />` tags to add Haxe defines (similar to using a `<haxeflag />` wi
 ```
 
 </details>
+
 <details>
-<summary>### `<setenv />`</summary>
+<summary>
+### `<setenv />`</summary>
 
 Use `<setenv />` tags to set environment variables:
 
@@ -281,8 +308,10 @@ Use `<setenv />` tags to set environment variables:
 ```
 
 </details>
+
 <details>
-<summary>### `<java />`</summary>
+<summary>
+### `<java />`</summary>
 
 Use `<java />` tags to add Java classes to the project when targeting Android:
 
@@ -291,8 +320,10 @@ Use `<java />` tags to add Java classes to the project when targeting Android:
 ```
 
 </details>
+
 <details>
-<summary>### `<certificate />`</summary>
+<summary>
+### `<certificate />`</summary>
 
 Use `<certificate />` tags to add a keystore for release signing on certain platforms.
 
@@ -313,8 +344,10 @@ iOS does not use a certificate `path` and `password`, but instead uses a `team-i
 ```
 
 </details>
+
 <details>
-<summary>### `<config:ios />`</summary>
+<summary>
+### `<config:ios />`</summary>
 
 Control iOS-specific values when compiling.
 
@@ -326,8 +359,10 @@ The `deployment` attribute can set the minimum iOS version you wish to target. T
 ```
 
 </details>
+
 <details>
-<summary>### `<config:android />`</summary>
+<summary>
+### `<config:android />`</summary>
 
 Use `<config:android />` tags to set Android-specific values:
 
@@ -338,8 +373,10 @@ Use `<config:android />` tags to set Android-specific values:
 ```
 
 </details>
+
 <details>
-<summary>### `<architecture />`</summary>
+<summary>
+### `<architecture />`</summary>
 
 Use `<architecture />` tags to set or exclude Android-specific architectures. These can be `ARMv7`, `ARMv6`, `ARMv5` and `X86`.
 
@@ -352,8 +389,10 @@ For example, if you want to enable `ARMv6` and disable `ARMv7` you would set the
 ```
 
 </details>
+
 <details>
-<summary>### `<dependency />`</summary>
+<summary>
+### `<dependency />`</summary>
 
 Use `<dependency />` tags to specify native frameworks or references that are required to compile your project, as well as additional libraries you need copied.
 
@@ -362,8 +401,10 @@ Use `<dependency />` tags to specify native frameworks or references that are re
 ```
 
 </details>
+
 <details>
-<summary>### `<path />`</summary>
+<summary>
+### `<path />`</summary>
 
 Use `<path />` tags to add directories to your system's PATH environment variable.
 
@@ -372,8 +413,10 @@ Use `<path />` tags to add directories to your system's PATH environment variabl
 ```
 
 </details>
+
 <details>
-<summary>### `<library />`</summary>
+<summary>
+### `<library />`</summary>
 
 All assets go into the “default” library, but by adding `<library>` tags it is possible to modify the default library and also define additional libraries and load/unload them as needed.
 

--- a/_docs/project-files/xml-format.md
+++ b/_docs/project-files/xml-format.md
@@ -370,7 +370,16 @@ Sets the path to launch image of the app (image which will be shown at applicati
 
 <details>
 <summary>&lt;launchstoryboard /&gt;</summary>
-More to come.
+Sets launch screen storyboard (useful only for iOS development)
+
+`<launchstoryboard path="image.png" />`
+
+or
+
+`<launchstoryboard name="image.png" />`
+
+You can also use `template` for it (will be documented in the future)
+
 </details>
 
 <details>

--- a/_docs/project-files/xml-format.md
+++ b/_docs/project-files/xml-format.md
@@ -509,7 +509,13 @@ Lets you set pre build commands, which could be Haxe code (will be interpeted by
 
 <details>
 <summary>&lt;preloader /&gt;</summary>
-More to come.
+Deprecated!!!
+Use `<app preloader="preloaderClass" />` instead
+	
+```
+<preloader name="preloaderClass" />
+```
+	
 </details>
 
 <details>

--- a/_docs/project-files/xml-format.md
+++ b/_docs/project-files/xml-format.md
@@ -362,7 +362,10 @@ Adds language to the list of supported languages (by default the list is empty)
 
 <details>
 <summary>&lt;launchimage /&gt;</summary>
-More to come.
+Sets the path to launch image of the app (image which will be shown at application start up)
+
+`<launchimage path="launchImage.png" />`
+	
 </details>
 
 <details>

--- a/_docs/project-files/xml-format.md
+++ b/_docs/project-files/xml-format.md
@@ -353,7 +353,11 @@ Use `<java />` tags to add Java classes to the project when targeting Android:
 
 <details>
 <summary>&lt;language /&gt;</summary>
-More to come.
+
+Add language to the list of supported languages (by default the list is empty)
+
+`<language name="en-US" />`
+
 </details>
 
 <details>

--- a/_docs/project-files/xml-format.md
+++ b/_docs/project-files/xml-format.md
@@ -354,7 +354,7 @@ Use `<java />` tags to add Java classes to the project when targeting Android:
 <details>
 <summary>&lt;language /&gt;</summary>
 
-Add language to the list of supported languages (by default the list is empty)
+Adds language to the list of supported languages (by default the list is empty)
 
 `<language name="en-US" />`
 


### PR DESCRIPTION
Added missing tags to documentation. Organised alphabetically and with expanding interface (at least as viewed on GitHub--please check this will work on the Lime site).