### PR TITLE
Give xsd files a maximum 1 minute cache time

### DIFF
--- a/_scripts/deploy.sh
+++ b/_scripts/deploy.sh
@@ -13,5 +13,9 @@ do
 	{ zopfli ${file} && mv -f ${file}.gz ${file}; }
 	#gzip -t ${file} > /dev/null 2>&1 || { gzip -9 ${file} && mv -f ${file}.gz ${file}; }
 done
+#gzipped files max cache 1 minute
 aws s3 sync . s3://lime.software --acl bucket-owner-full-control --acl public-read --size-only --delete --exclude="*" --include="*.css" --include="*.txt" --include="*.js" --include="*.json" --include="*.htm" --include="*.html" --include="*.map" --include="*.xml" --content-encoding gzip --cache-control max-age=3600
-aws s3 sync . s3://lime.software --acl bucket-owner-full-control --acl public-read --size-only --delete --include="*" --exclude="*.css" --exclude="*.txt" --exclude="*.js" --exclude="*.json" --exclude="*.htm" --exclude="*.html" --exclude="*.map" --exclude="*.xml" --cache-control max-age=864000
+#uncompressed files max cache 1 minute
+aws s3 sync . s3://lime.software --acl bucket-owner-full-control --acl public-read --size-only --delete --exclude="*" --include="*.xsd" --cache-control max-age=3600
+#uncompressed files max cache 7 days
+aws s3 sync . s3://lime.software --acl bucket-owner-full-control --acl public-read --size-only --delete --include="*" --exclude="*.css" --exclude="*.txt" --exclude="*.js" --exclude="*.json" --exclude="*.htm" --exclude="*.html" --exclude="*.map" --exclude="*.xml" --exclude="*.xsd" --cache-control max-age=864000


### PR DESCRIPTION
XSD files were recently added to our website and they have an odd cache time of 7 days instead of 1 minute like the rest of the core files. 

This pull allows xsd files to get a 1 minute max-age,