### PR TITLE
Update XML format example for conditional values

### DIFF
--- a/_docs/project-files/xml-format.md
+++ b/_docs/project-files/xml-format.md
@@ -59,7 +59,7 @@ lime test flash -Dblue
 If you need to have multiple values in a conditional, spaces imply an "and" and vertical bars imply an "or", like this:
 
 ```xml
-<window width="640" height="480" if="define define2" unless="define3 || define4" />
+<window width="640" height="480" if="define || define2" unless="define3 || define4" />
 ```
 
 If a value isn't found, either because it was never set or because of [`<unset />`](#unset)/[`<undefine />`](#undefine), it will be treated as `false`.


### PR DESCRIPTION
The current example conditional does not use the pipes `||` between multiple `if` values, which fails.

Noted in discussion here:
https://community.openfl.org/t/regarding-project-xml/14477/8?u=bink

Confirmed handling with example here:
https://github.com/openfl/lime/blob/adb5f5c5e7fe73b5ff666f3d66fc0501b385d84e/include.xml#L10

Use `||` between multiple `if` values.